### PR TITLE
chore: decouple library crate versions from workspace package version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,11 @@ jobs:
         name: Compare version with Git tag
         run: |
           set -euo pipefail
+          # The release tag tracks the workspace product version
+          # ([workspace.package] in Cargo.toml), which hya-gui, hya-cli and
+          # hya-host inherit and ship under as one bundle. The library crates
+          # (hya-core, hya-net) version independently and are checked by the
+          # publish-crates job against their own manifests instead.
           VERSION=$(grep -m1 '^version = ' Cargo.toml | cut -d'"' -f2)
           TAG="${GITHUB_REF_NAME#v}"
           echo "manifest=$VERSION tag=$TAG"
@@ -244,10 +249,10 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_PUBLISH_TOKEN || secrets.CRATES_IO_TOKEN }}
         run: |
           set -euo pipefail
-          VERSION=$(grep -m1 '^version = ' Cargo.toml | cut -d'"' -f2)
-          echo "Publishing workspace version ${VERSION}"
 
-          USER_AGENT="hydra-release-ci (${VERSION}; +https://github.com/ja7ad/hydra)"
+          crate_version() {
+            grep -m1 '^version = ' "crates/$1/Cargo.toml" | cut -d'"' -f2
+          }
 
           sparse_index_url() {
             local name
@@ -265,34 +270,43 @@ jobs:
           }
 
           is_indexed() {
-            local name="$1"
-            curl -sf -A "$USER_AGENT" "$(sparse_index_url "$name")" \
-              | grep -q "\"vers\":\"${VERSION}\""
+            local name="$1" version="$2" user_agent="$3"
+            curl -sf -A "$user_agent" "$(sparse_index_url "$name")" \
+              | grep -q "\"vers\":\"${version}\""
           }
 
           publish_crate() {
             local name="$1"
-            if is_indexed "$name"; then
-              echo "${name} ${VERSION} is already published, skipping"
+            # crates.io name -> manifest directory: crates/hydra-core holds
+            # the hya-core crate, crates/hydra-net holds hya-net.
+            local dir="hydra-${name#hya-}"
+            local version user_agent
+            version=$(crate_version "$dir")
+            user_agent="hydra-release-ci (${name} ${version}; +https://github.com/ja7ad/hydra)"
+            if is_indexed "$name" "$version" "$user_agent"; then
+              echo "${name} ${version} is already published, skipping"
               return
             fi
-            echo "Publishing ${name} ${VERSION}"
+            echo "Publishing ${name} ${version}"
             cargo publish -p "${name}" --locked
-            echo "Waiting for ${name} ${VERSION} to be indexed on crates.io..."
+            echo "Waiting for ${name} ${version} to be indexed on crates.io..."
             for _ in $(seq 1 60); do
-              if is_indexed "$name"; then
-                echo "${name} ${VERSION} is live"
+              if is_indexed "$name" "$version" "$user_agent"; then
+                echo "${name} ${version} is live"
                 return
               fi
               sleep 10
             done
-            echo "Timed out waiting for ${name} ${VERSION} to be indexed" >&2
+            echo "Timed out waiting for ${name} ${version} to be indexed" >&2
             exit 1
           }
 
-          # Publish in topological dependency order. Only the library crates go
-          # to crates.io; hya-cli / hya-gui / hya-host are `publish = false`
-          # and ship as release binaries instead:
+          # Publish in topological dependency order. The library crates each
+          # carry their own independent version (crates/hydra-{core,net}/
+          # Cargo.toml), separate from the workspace product version, so each
+          # is read and published against its own manifest. Only the library
+          # crates go to crates.io; hya-cli / hya-gui / hya-host are
+          # `publish = false` and ship as release binaries instead:
           # 1. hya-core (pure algorithmic foundation, no intra-workspace deps)
           # 2. hya-net (depends on hya-core)
           publish_crate hya-core

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,11 @@ members = ["crates/hydra-core", "crates/hydra-net", "crates/hydra-cli", "crates/
 resolver = "2"
 
 [workspace.package]
+# The product version: hya-cli, hya-gui and hya-host inherit this via
+# `version.workspace = true` and move together as one "Hydra Download
+# Manager" release. The library crates (hya-core, hya-net) do NOT inherit
+# it — each carries its own version in its manifest and bumps independently
+# on its own semver cadence.
 version = "0.2.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@
 # PROFILE=dist make build   selects the smaller panic=abort profile (Cargo.toml).
 
 UNAME   := $(shell uname -s)
+# The workspace product version ([workspace.package] in Cargo.toml), shared
+# by the GUI, CLI and host bin crates that every package target bundles.
+# The library crates version independently and don't affect artifact names.
 VERSION := $(shell sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
 PROFILE ?= release
 CARGO   ?= cargo

--- a/crates/hydra-core/Cargo.toml
+++ b/crates/hydra-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hya-core"
-version.workspace = true
+version = "0.2.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/hydra-net/Cargo.toml
+++ b/crates/hydra-net/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hya-net"
-version.workspace = true
+version = "0.2.2"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/scripts/build-windows-installer.sh
+++ b/scripts/build-windows-installer.sh
@@ -37,6 +37,8 @@ case "$ARCH" in
   x64)   TARGET="x86_64-pc-windows-msvc" ;;
 esac
 
+# The workspace product version ([workspace.package]), shared by the
+# hydra-gui, hydra-cli and hydra-host bin crates this installer bundles.
 VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
 
 if [ "$NO_BUILD" = 0 ]; then

--- a/scripts/macos-app-bundle.sh
+++ b/scripts/macos-app-bundle.sh
@@ -15,6 +15,8 @@ cd "$(dirname "$0")/.."
 INSTALL=0
 [ "${1:-}" = "--install" ] && INSTALL=1
 
+# The workspace product version ([workspace.package]), shared by the
+# hydra-gui, hydra-cli and hydra-host bin crates this bundle carries.
 VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
 
 cargo build --release -p hya-gui -p hya-host -p hya-cli

--- a/scripts/package-linux.sh
+++ b/scripts/package-linux.sh
@@ -44,6 +44,8 @@ esac
 
 NAME=hydra-download-manager
 HOST_NAME=com.hydra.host
+# The workspace product version ([workspace.package]), shared by the
+# hydra-gui, hydra-cli and hydra-host bin crates this package bundles.
 VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
 SUMMARY="Multi-connection download manager (GUI, CLI, browser integration)"
 OUT="$REPO/target/dist"

--- a/scripts/package-macos-dmg.sh
+++ b/scripts/package-macos-dmg.sh
@@ -26,6 +26,8 @@ cd "$REPO"
 
 scripts/macos-app-bundle.sh
 
+# The workspace product version ([workspace.package]), shared by the
+# hydra-gui, hydra-cli and hydra-host bin crates the .app bundle carries.
 VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
 # With CARGO_BUILD_TARGET set (CI cross-arch builds), the bundle script puts
 # the .app under target/<triple>/release, and the arch in the image name must

--- a/scripts/package-macos-pkg.sh
+++ b/scripts/package-macos-pkg.sh
@@ -29,6 +29,8 @@ cd "$REPO"
 
 scripts/macos-app-bundle.sh
 
+# The workspace product version ([workspace.package]), shared by the
+# hydra-gui, hydra-cli and hydra-host bin crates the .pkg carries.
 VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
 # With CARGO_BUILD_TARGET set (CI cross-arch builds), the bundle script puts
 # the .app under target/<triple>/release, and the arch in the package name


### PR DESCRIPTION
- Set explicit independent versions for hya-core and hya-net manifests instead of inheriting workspace version
- Update release CI workflow to read and verify versions per-crate when publishing to crates.io
- Clarify workspace product version role across Makefile and packaging scripts