### PR TITLE
feat: add Homebrew tap support and documentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,6 +235,9 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -260,3 +263,24 @@ jobs:
           generate_release_notes: true
           prerelease: ${{ needs.verify-version.outputs.prerelease == 'true' }}
           make_latest: ${{ needs.verify-version.outputs.prerelease != 'true' }}
+
+      - name: Update Homebrew Tap
+        if: needs.verify-version.outputs.prerelease != 'true'
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -n "${HOMEBREW_TAP_TOKEN:-}" ]; then
+            git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/ja7ad/homebrew-tap.git" tap
+            scripts/update-homebrew.sh "${{ needs.verify-version.outputs.version }}" dist tap
+            cd tap
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add Formula/hydra.rb Casks/hydra.rb
+            if ! git diff --staged --quiet; then
+              git commit -m "chore(hydra): bump to v${{ needs.verify-version.outputs.version }}"
+              git push origin main
+            fi
+          else
+            echo "note: HOMEBREW_TAP_TOKEN not set; skipping automated tap update"
+          fi

--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@
 
 ## Installation
 
+### Homebrew (macOS / Linux)
+
+**CLI**:
+
+```bash
+brew install ja7ad/tap/hydra
+```
+
+**macOS Desktop App (GUI)**:
+
+```bash
+brew install --cask ja7ad/tap/hydra
+```
+
 ### Quick Install (prebuilt binaries)
 
 **macOS / Linux** — installs the GUI bundle (GUI + CLI + browser extensions) by default:
@@ -124,6 +138,16 @@ To also delete config and state:
 
 ```powershell
 & ([scriptblock]::Create((irm https://raw.githubusercontent.com/ja7ad/hydra/main/uninstall.ps1))) -Purge
+```
+
+**Homebrew**:
+
+```bash
+# Uninstall CLI
+brew uninstall hydra
+
+# Uninstall macOS Desktop App (and zap settings)
+brew uninstall --cask --zap hydra
 ```
 
 The scripts remove binaries, extensions, manifests, desktop shortcuts, and startup entries. On macOS, they also remove the bundled app and package receipts. Config and state are kept by default (`~/.config/hydra` on Linux/macOS, `%APPDATA%\hydra` on Windows); use `--purge` / `-Purge` to delete them.

--- a/docs/index.html
+++ b/docs/index.html
@@ -549,11 +549,18 @@
       <div class="install-tabs">
         <div class="tab-row" role="tablist" aria-label="Install command by platform">
           <button class="tab active" role="tab" aria-selected="true" data-target="cmd-unix">macOS / Linux</button>
+          <button class="tab" role="tab" aria-selected="false" data-target="cmd-brew">Homebrew</button>
           <button class="tab" role="tab" aria-selected="false" data-target="cmd-win">Windows</button>
         </div>
         <div class="cmd active" id="cmd-unix">
           <code><b>curl</b> -fsSL https://raw.githubusercontent.com/ja7ad/hydra/main/install.sh | <b>bash</b></code>
           <button class="copy" aria-label="Copy install command" data-copy="curl -fsSL https://raw.githubusercontent.com/ja7ad/hydra/main/install.sh | bash">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="8" y="8" width="13" height="13" rx="2"/><path d="M16 8V6a2 2 0 00-2-2H5a2 2 0 00-2 2v9a2 2 0 002 2h2"/></svg>
+          </button>
+        </div>
+        <div class="cmd" id="cmd-brew">
+          <code><b>brew</b> install ja7ad/tap/hydra</code>
+          <button class="copy" aria-label="Copy install command" data-copy="brew install ja7ad/tap/hydra">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="8" y="8" width="13" height="13" rx="2"/><path d="M16 8V6a2 2 0 00-2-2H5a2 2 0 00-2 2v9a2 2 0 002 2h2"/></svg>
           </button>
         </div>

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,10 @@
 # <prefix>/bin, browser extensions + native-host installer into
 # <prefix>/share/hydra. On Linux this uses the release tarball (no deb/rpm
 # needed). --cli installs only the hydra binary.
+#
+# Homebrew users on macOS/Linux can also run:
+#   brew install ja7ad/tap/hydra         # CLI
+#   brew install --cask ja7ad/tap/hydra  # macOS Desktop GUI bundle
 
 set -euo pipefail
 

--- a/scripts/update-homebrew.sh
+++ b/scripts/update-homebrew.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Copyright (C) 2026 Javad Rajabzadeh
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Update Formula/hydra.rb and Casks/hydra.rb for a release.
+#
+#   scripts/update-homebrew.sh [vX.Y.Z] [DIST_DIR]
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+VERSION="${1:-}"
+if [ -z "$VERSION" ]; then
+  VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
+fi
+VERSION="${VERSION#v}"
+TAG="v${VERSION}"
+DIST="${2:-dist}"
+TAP_DIR="${3:-${HOMEBREW_TAP_DIR:-../homebrew-tap}}"
+
+echo "Updating Homebrew tap at ${TAP_DIR} for version ${VERSION} (tag ${TAG})..."
+
+mkdir -p "${TAP_DIR}/Formula" "${TAP_DIR}/Casks"
+
+# 1. Formula sha256 (source tarball)
+SOURCE_URL="https://github.com/ja7ad/hydra/archive/refs/tags/${TAG}.tar.gz"
+echo "Fetching source tarball SHA256..."
+FORMULA_SHA=$(curl -fsSL "$SOURCE_URL" | sha256sum | awk '{print $1}') || FORMULA_SHA=""
+if [ -z "$FORMULA_SHA" ]; then
+  echo "warning: could not fetch remote tarball; computing from git archive" >&2
+  TMP_TAR=$(mktemp)
+  git archive --format=tar.gz --prefix="hydra-${VERSION}/" "$TAG" -o "$TMP_TAR"
+  FORMULA_SHA=$(sha256sum "$TMP_TAR" | awk '{print $1}')
+  rm -f "$TMP_TAR"
+fi
+
+# 2. Cask sha256s (DMGs)
+DMG_ARM_SHA=""
+DMG_INTEL_SHA=""
+
+if [ -f "$DIST/SHA256SUMS.txt" ]; then
+  DMG_ARM_SHA=$(grep "Hydra-${VERSION}-arm64.dmg" "$DIST/SHA256SUMS.txt" | awk '{print $1}' || true)
+  DMG_INTEL_SHA=$(grep "Hydra-${VERSION}-x86_64.dmg" "$DIST/SHA256SUMS.txt" | awk '{print $1}' || true)
+fi
+
+if [ -z "$DMG_ARM_SHA" ] && [ -f "$DIST/Hydra-${VERSION}-arm64.dmg" ]; then
+  DMG_ARM_SHA=$(sha256sum "$DIST/Hydra-${VERSION}-arm64.dmg" | awk '{print $1}')
+fi
+
+if [ -z "$DMG_INTEL_SHA" ] && [ -f "$DIST/Hydra-${VERSION}-x86_64.dmg" ]; then
+  DMG_INTEL_SHA=$(sha256sum "$DIST/Hydra-${VERSION}-x86_64.dmg" | awk '{print $1}')
+fi
+
+# Update ${TAP_DIR}/Formula/hydra.rb
+cat > "${TAP_DIR}/Formula/hydra.rb" <<EOF
+class Hydra < Formula
+  desc "Fast, resilient, multi-source file retriever and download engine"
+  homepage "https://github.com/ja7ad/hydra"
+  url "https://github.com/ja7ad/hydra/archive/refs/tags/${TAG}.tar.gz"
+  sha256 "${FORMULA_SHA}"
+  license "GPL-3.0-or-later"
+  head "https://github.com/ja7ad/hydra.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args(path: "crates/hydra-cli")
+
+    man1.install Dir["docs/man/*.1"] if Dir.exist?("docs/man")
+
+    generate_completions_from_executable(bin/"hydra", "completions")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/hydra --version")
+  end
+end
+EOF
+
+# Update ${TAP_DIR}/Casks/hydra.rb if DMG SHA256s are available
+if [ -n "$DMG_ARM_SHA" ] && [ -n "$DMG_INTEL_SHA" ]; then
+cat > "${TAP_DIR}/Casks/hydra.rb" <<EOF
+cask "hydra" do
+  arch arm: "arm64", intel: "x86_64"
+
+  version "${VERSION}"
+  sha256 arm:   "${DMG_ARM_SHA}",
+         intel: "${DMG_INTEL_SHA}"
+
+  url "https://github.com/ja7ad/hydra/releases/download/v#{version}/Hydra-#{version}-#{arch}.dmg"
+  name "Hydra"
+  desc "Multi-source file retriever and download manager"
+  homepage "https://github.com/ja7ad/hydra"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on macos: :big_sur
+
+  app "Hydra Download Manager.app"
+  binary "#{appdir}/Hydra Download Manager.app/Contents/MacOS/hydra"
+  manpage "#{appdir}/Hydra Download Manager.app/Contents/Resources/man/man1/hydra.1"
+
+  zap trash: [
+    "~/.config/hydra",
+    "~/Library/Application Support/Hydra",
+    "~/Library/Preferences/io.github.ja7ad.hydra.plist",
+    "~/Library/Saved Application State/io.github.ja7ad.hydra.savedState",
+  ]
+end
+EOF
+fi
+
+echo "Tap at ${TAP_DIR} updated successfully."

--- a/scripts/update-homebrew.sh
+++ b/scripts/update-homebrew.sh
@@ -36,21 +36,30 @@ if [ -z "$FORMULA_SHA" ]; then
   rm -f "$TMP_TAR"
 fi
 
-# 2. Cask sha256s (DMGs)
+# 2. Cask sha256s (macOS DMGs & Linux Tarballs)
 DMG_ARM_SHA=""
 DMG_INTEL_SHA=""
+LINUX_ARM_SHA=""
+LINUX_AMD_SHA=""
 
 if [ -f "$DIST/SHA256SUMS.txt" ]; then
   DMG_ARM_SHA=$(grep "Hydra-${VERSION}-arm64.dmg" "$DIST/SHA256SUMS.txt" | awk '{print $1}' || true)
   DMG_INTEL_SHA=$(grep "Hydra-${VERSION}-x86_64.dmg" "$DIST/SHA256SUMS.txt" | awk '{print $1}' || true)
+  LINUX_ARM_SHA=$(grep "hydra-${VERSION}-linux-arm64.tar.gz" "$DIST/SHA256SUMS.txt" | awk '{print $1}' || true)
+  LINUX_AMD_SHA=$(grep "hydra-${VERSION}-linux-amd64.tar.gz" "$DIST/SHA256SUMS.txt" | awk '{print $1}' || true)
 fi
 
 if [ -z "$DMG_ARM_SHA" ] && [ -f "$DIST/Hydra-${VERSION}-arm64.dmg" ]; then
   DMG_ARM_SHA=$(sha256sum "$DIST/Hydra-${VERSION}-arm64.dmg" | awk '{print $1}')
 fi
-
 if [ -z "$DMG_INTEL_SHA" ] && [ -f "$DIST/Hydra-${VERSION}-x86_64.dmg" ]; then
   DMG_INTEL_SHA=$(sha256sum "$DIST/Hydra-${VERSION}-x86_64.dmg" | awk '{print $1}')
+fi
+if [ -z "$LINUX_ARM_SHA" ] && [ -f "$DIST/hydra-${VERSION}-linux-arm64.tar.gz" ]; then
+  LINUX_ARM_SHA=$(sha256sum "$DIST/hydra-${VERSION}-linux-arm64.tar.gz" | awk '{print $1}')
+fi
+if [ -z "$LINUX_AMD_SHA" ] && [ -f "$DIST/hydra-${VERSION}-linux-amd64.tar.gz" ]; then
+  LINUX_AMD_SHA=$(sha256sum "$DIST/hydra-${VERSION}-linux-amd64.tar.gz" | awk '{print $1}')
 fi
 
 # Update ${TAP_DIR}/Formula/hydra.rb
@@ -79,17 +88,48 @@ class Hydra < Formula
 end
 EOF
 
-# Update ${TAP_DIR}/Casks/hydra.rb if DMG SHA256s are available
+# Update ${TAP_DIR}/Casks/hydra.rb if checksums are available
 if [ -n "$DMG_ARM_SHA" ] && [ -n "$DMG_INTEL_SHA" ]; then
 cat > "${TAP_DIR}/Casks/hydra.rb" <<EOF
 cask "hydra" do
-  arch arm: "arm64", intel: "x86_64"
-
   version "${VERSION}"
-  sha256 arm:   "${DMG_ARM_SHA}",
-         intel: "${DMG_INTEL_SHA}"
 
-  url "https://github.com/ja7ad/hydra/releases/download/v#{version}/Hydra-#{version}-#{arch}.dmg"
+  on_macos do
+    arch arm: "arm64", intel: "x86_64"
+
+    sha256 arm:   "${DMG_ARM_SHA}",
+           intel: "${DMG_INTEL_SHA}"
+
+    url "https://github.com/ja7ad/hydra/releases/download/v#{version}/Hydra-#{version}-#{arch}.dmg"
+
+    depends_on macos: :big_sur
+
+    app "Hydra Download Manager.app"
+    binary "#{appdir}/Hydra Download Manager.app/Contents/MacOS/hydra"
+    manpage "#{appdir}/Hydra Download Manager.app/Contents/Resources/man/man1/hydra.1"
+  end
+EOF
+
+if [ -n "$LINUX_ARM_SHA" ] && [ -n "$LINUX_AMD_SHA" ]; then
+cat >> "${TAP_DIR}/Casks/hydra.rb" <<EOF
+  on_linux do
+    arch arm: "arm64", intel: "amd64"
+
+    sha256 arm:   "${LINUX_ARM_SHA}",
+           intel: "${LINUX_AMD_SHA}"
+
+    url "https://github.com/ja7ad/hydra/releases/download/v#{version}/hydra-#{version}-linux-#{arch}.tar.gz"
+
+    binary "hydra-#{version}-linux-#{arch}/hydra"
+    binary "hydra-#{version}-linux-#{arch}/hydra-gui"
+    binary "hydra-#{version}-linux-#{arch}/hydra-host"
+    manpage "hydra-#{version}-linux-#{arch}/man/hydra.1"
+  end
+EOF
+fi
+
+cat >> "${TAP_DIR}/Casks/hydra.rb" <<EOF
+
   name "Hydra"
   desc "Multi-source file retriever and download manager"
   homepage "https://github.com/ja7ad/hydra"
@@ -100,11 +140,6 @@ cask "hydra" do
   end
 
   auto_updates true
-  depends_on macos: :big_sur
-
-  app "Hydra Download Manager.app"
-  binary "#{appdir}/Hydra Download Manager.app/Contents/MacOS/hydra"
-  manpage "#{appdir}/Hydra Download Manager.app/Contents/Resources/man/man1/hydra.1"
 
   zap trash: [
     "~/.config/hydra",

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -68,6 +68,16 @@ if [ "$OS" = linux ]; then
   fi
 fi
 
+# Homebrew installs are managed by brew.
+if command -v brew >/dev/null 2>&1; then
+  if brew list --formula hydra >/dev/null 2>&1 || brew list --formula ja7ad/tap/hydra >/dev/null 2>&1; then
+    echo "note: hydra CLI was installed via Homebrew; to remove run: brew uninstall hydra" >&2
+  fi
+  if brew list --cask hydra >/dev/null 2>&1 || brew list --cask ja7ad/tap/hydra >/dev/null 2>&1; then
+    echo "note: hydra app was installed via Homebrew Cask; to remove run: brew uninstall --cask hydra" >&2
+  fi
+fi
+
 # Man pages, by exact name: a glob like hydra*.1 could hit the unrelated
 # THC hydra(1) if it shares the prefix.
 MAN_PAGES=(hydra.1 hydra-interactive.1 hydra-checksum.1 hydra-parity.1


### PR DESCRIPTION
## Summary

Adds official Homebrew distribution support for Hydra via a dedicated tap (`ja7ad/homebrew-tap`), covering both the **CLI binary (Formula)** and the **macOS Desktop GUI application (Cask)**.

---

## What's Changed

- **Documentation & Website**:
  - Added Homebrew installation and uninstallation guides to `README.md`.
  - Added an interactive **Homebrew** tab with copy functionality in `docs/index.html`.
- **Scripts**:
  - Added `scripts/update-homebrew.sh` to dynamically compute tarball/DMG checksums and update the tap's formula and cask on releases.
  - Added Homebrew tips and package manager detection in `install.sh` and `uninstall.sh`.
- **Release Automation**:
  - Updated `.github/workflows/release.yml` with an automated step to sync and commit new release versions directly to `ja7ad/homebrew-tap` (runs when `HOMEBREW_TAP_TOKEN` secret is configured).

---

## Homebrew Tap Setup

The companion tap repository (`ja7ad/homebrew-tap`) contains:
- `Formula/hydra.rb`: Builds `hydra` CLI from source with `cargo install`, man pages (`docs/man/*.1`), and auto-generated shell completions (bash, zsh, fish).
- `Casks/hydra.rb`: Installs `Hydra Download Manager.app` from official GitHub release DMGs (`arm64` and `x86_64`), symlinks the binary, and sets up `zap` paths.

### User Installation Commands:
```bash
# Install Hydra CLI
brew install ja7ad/tap/hydra

# Install Hydra Desktop GUI app (macOS)
brew install --cask ja7ad/tap/hydra
