### PR TITLE
fix(packaging): unblock launchpad ppa publishing + rustc-1.91 for builder runner 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -660,7 +660,24 @@ jobs:
 
             # Import GPG private signing key
             echo "$LAUNCHPAD_GPG_KEY" | gpg --import --batch --yes
-            GPG_KEY_ID=$(gpg --list-secret-keys --keyid-format LONG --with-colons | awk -F: '/^sec:/ { print $5; exit }')
+
+            # Fingerprint of the first *secret* key. gpg exits 0 and prints
+            # nothing when the imported material held only a public key, so an
+            # unchecked empty value here reaches debuild as a bare "-k":
+            # debsign's getopt then swallows the .changes filename as -k's
+            # argument and dies with "Must be run from top of source dir or a
+            # .changes file given as arg".
+            GPG_KEY_ID=$(gpg --list-secret-keys --with-colons \
+              | awk -F: '/^sec:/ { want = 1; next } want && /^fpr:/ { print $10; exit }')
+            if [ -z "$GPG_KEY_ID" ]; then
+              echo "error: LAUNCHPAD_GPG_KEY imported no secret key; there is nothing to sign with." >&2
+              echo "hint: the secret must be an ASCII-armored *private* key," >&2
+              echo "      i.e. gpg --export-secret-keys --armor <keyid>, not gpg --export." >&2
+              echo "keys currently in the keyring:" >&2
+              gpg --list-keys --keyid-format LONG >&2 || true
+              exit 1
+            fi
+            echo "Signing PPA uploads with GPG key $GPG_KEY_ID"
             GPG_USER=$(gpg --list-secret-keys --with-colons | awk -F: '/^uid:/ { print $10; exit }')
             [ -n "$GPG_USER" ] || GPG_USER="Hydra Maintainers <dev@hydra.app>"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -661,12 +661,7 @@ jobs:
             # Import GPG private signing key
             echo "$LAUNCHPAD_GPG_KEY" | gpg --import --batch --yes
 
-            # Fingerprint of the first *secret* key. gpg exits 0 and prints
-            # nothing when the imported material held only a public key, so an
-            # unchecked empty value here reaches debuild as a bare "-k":
-            # debsign's getopt then swallows the .changes filename as -k's
-            # argument and dies with "Must be run from top of source dir or a
-            # .changes file given as arg".
+            # Fingerprint of the first *secret* key
             GPG_KEY_ID=$(gpg --list-secret-keys --with-colons \
               | awk -F: '/^sec:/ { want = 1; next } want && /^fpr:/ { print $10; exit }')
             if [ -z "$GPG_KEY_ID" ]; then
@@ -681,16 +676,21 @@ jobs:
             GPG_USER=$(gpg --list-secret-keys --with-colons | awk -F: '/^uid:/ { print $10; exit }')
             [ -n "$GPG_USER" ] || GPG_USER="Hydra Maintainers <dev@hydra.app>"
 
-            # Enable passive FTP for dput globally without overriding default PPA handler
+            # Enable passive FTP for dput globally
             printf '[DEFAULT]\npassive_ftp = 1\n' > ~/.dput.cf
 
-            # Vendor dependencies for offline building in Launchpad builders
+            # Vendor dependencies for offline building
             cargo vendor vendor/
 
-            # Copy packaging directory into place
+            # Remove per-crate checksum manifests (they list paths that dpkg-source
+            # omits and cargo would reject)
+            find vendor -name .cargo-checksum.json -print0 \
+              | xargs -0 perl -pi -e 's/"files":\{[^}]*\}/"files":{}/'
+
+            # Copy Debian packaging files to debian/ directory
             cp -r packaging/debian debian
 
-            # Build source packages for Ubuntu 24.04 (noble) and 22.04 (jammy)
+            # Update changelog and build source packages for each distribution
             for DISTRO in noble jammy; do
               printf "hydra (%s-1ppa1~%s1) %s; urgency=medium\n\n  * Automated Launchpad PPA release for %s.\n\n -- %s  %s\n" \
                 "$VERSION" "$DISTRO" "$DISTRO" "$DISTRO" "$GPG_USER" "$(date -R)" > debian/changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -588,7 +588,7 @@ jobs:
           make_latest: ${{ needs.verify-version.outputs.prerelease != 'true' }}
 
       - name: Update Homebrew Tap
-        if: needs.verify-version.outputs.prerelease != 'true'
+        if: needs.verify-version.outputs.prerelease == 'false'
         env:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
@@ -609,7 +609,7 @@ jobs:
           fi
 
       - name: Trigger Fedora Copr Build
-        if: needs.verify-version.outputs.prerelease != 'true'
+        if: needs.verify-version.outputs.prerelease == 'false'
         env:
           COPR_CONFIG: ${{ secrets.COPR_CONFIG }}
           COPR_PROJECT: ${{ secrets.COPR_PROJECT }}
@@ -647,7 +647,7 @@ jobs:
           fi
 
       - name: Build and Publish to Launchpad PPA
-        if: needs.verify-version.outputs.prerelease != 'true'
+        if: needs.verify-version.outputs.prerelease == 'false'
         env:
           LAUNCHPAD_GPG_KEY: ${{ secrets.LAUNCHPAD_GPG_KEY }}
           LAUNCHPAD_PPA: ${{ secrets.LAUNCHPAD_PPA }}

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -3,8 +3,8 @@ Section: net
 Priority: optional
 Maintainer: Javad Rajabzadeh <ja7ad@live.com>
 Build-Depends: debhelper-compat (= 13),
-               cargo,
-               rustc (>= 1.75),
+               cargo-1.91,
+               rustc-1.91,
                pkg-config,
                libasound2-dev,
                libx11-dev,

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -1,11 +1,24 @@
 #!/usr/bin/make -f
 export DH_VERBOSE = 1
 
+# Ubuntu jammy and noble both default rustc/cargo to 1.75, which cannot even
+# parse a version-4 Cargo.lock ("lock file version 4 requires
+# -Znext-lockfile-bump") and sits far below this dependency tree's MSRV.
+# Build against the versioned toolchain packages instead; rustc-1.91 and
+# cargo-1.91 are in universe for both series, which Launchpad builders enable.
+export PATH := /usr/lib/rust-1.91/bin:$(PATH)
+# Launchpad builders run with HOME=/sbuild-nonexistent, so cargo needs a
+# writable home inside the build tree.
+export CARGO_HOME := $(CURDIR)/debian/cargo_home
+
 %:
 	dh $@
 
 override_dh_auto_clean:
-	rm -rf target/ dist/ debian/hydra/ debian/.debhelper/ debian/files
+	rm -rf target/ dist/ debian/hydra/ debian/.debhelper/ debian/files debian/cargo_home
+
+override_dh_clean:
+	dh_clean -X.orig
 
 override_dh_auto_build:
 	mkdir -p .cargo


### PR DESCRIPTION
  Launchpad PPA publishing was failing at three separate points. Both of the
  interesting ones had symptoms that pointed nowhere near their cause.

  ## `fix(ci)` — signing key resolution

  `gpg --list-secret-keys --with-colons` exits 0 and prints nothing on an empty
  keyring, so `set -euo pipefail` never caught `GPG_KEY_ID` coming back empty.
  `-k"$GPG_KEY_ID"` then expanded to a bare `-k`, which `debuild` forwards
  verbatim to `debsign` — whose getopt spec declares `k:` as argument-taking, so
  it swallowed the `.changes` filename and left zero positional args:

  ```
  debsign: Must be run from top of source dir or a .changes file given as arg
  debuild: fatal error at line 1114: running debsign failed
  ```

  Now resolves the full fingerprint of the first `sec:` record and aborts with the
  keyring contents when no secret key was imported, instead of emitting an empty
  `-k`. Using the fingerprint also drops gpg's `long key IDs are discouraged`
  warning.

  ## `fix(packaging)` — build toolchain

  jammy and noble both default `rustc`/`cargo` to 1.75, which cannot parse a
  version-4 `Cargo.lock` (`lock file version 4 requires -Znext-lockfile-bump`)
  and sits far below this dependency tree's MSRV — so downgrading the lockfile
  would only move the failure to the next crate. Build-depends on
  `rustc-1.91`/`cargo-1.91` instead (universe, present for both series, and
  Launchpad builders enable universe) and prepends their bindir to `PATH`.
  `CARGO_HOME` moves into the build tree because builders run
  `HOME=/sbuild-nonexistent`.