### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
Potential fix for [https://github.com/ja7ad/hydra/security/code-scanning/5](https://github.com/ja7ad/hydra/security/code-scanning/5)

Add an explicit workflow-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit restricted `GITHUB_TOKEN` access by default. The best minimal safe fix here is:

- `permissions:`
  - `contents: read`

Place this near the top of the workflow (after `on:` is a common location). This preserves existing functionality for checkout/build/test style jobs while documenting and enforcing least privilege. No imports, methods, or external definitions are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
