### PR TITLE
Potential fix for code scanning alert no. 6: Access of invalid pointer

### DIFF
--- a/crates/hydra-ffi/src/convert.rs
+++ b/crates/hydra-ffi/src/convert.rs
@@ -102,10 +102,7 @@ pub(crate) unsafe fn engine_cfg(p: *const hydra_engine_config_t) -> Result<Engin
     out.worker_threads = c.worker_threads.min(1024) as usize;
     out.max_bytes_per_second = c.max_bytes_per_second;
 
-    let reaches = |off: usize| {
-        // SAFETY: reads size field from valid header prefix.
-        (unsafe { (p as *const u32).read_unaligned() } as usize) >= off
-    };
+    let reaches = |off: usize| (c.size as usize) >= off;
     let flags_off = std::mem::offset_of!(hydra_engine_config_t, reserved0) + 1;
     if reaches(flags_off) {
         out.adaptive_concurrency = c.adaptive_concurrency != 0;


### PR DESCRIPTION
Potential fix for [https://github.com/ja7ad/hydra/security/code-scanning/6](https://github.com/ja7ad/hydra/security/code-scanning/6)

General fix: avoid dereferencing raw pointers multiple times when validated/copied data is already available. In `unsafe` Rust, copy once from the raw pointer (with validation), then operate only on owned/local values.

Best fix here: in `crates/hydra-ffi/src/convert.rs`, inside `engine_cfg`, change the `reaches` closure to use `c.size` instead of `(p as *const u32).read_unaligned()`. Since `c` is the value returned by `read_versioned`, this preserves version/size-gated behavior while removing the extra raw-pointer read that CodeQL flags.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
