### PR TITLE
Fix download capture persistence when hydra is not running

### DIFF
--- a/crates/hydra-gui/src/app.rs
+++ b/crates/hydra-gui/src/app.rs
@@ -4186,7 +4186,7 @@ impl App {
 
             // ------------------------------------------- browser extension
             Message::Ext(ev) => match ev {
-                crate::extbus::ExtEvent::Download(dl) => {
+                crate::extbus::ExtEvent::Download(dl, ack) => {
                     // Same flow as a manual Add URL, so duplicate detection,
                     // categorization, and the File Info dialog all behave
                     // consistently for browser capture.
@@ -4199,7 +4199,12 @@ impl App {
                         capture_referer: dl.referer,
                         ..AddUrlState::default()
                     };
-                    self.update(Message::AddUrlOk)
+                    let task = self.update(Message::AddUrlOk);
+                    // The item is listed (or a duplicate dialog is up over
+                    // it): hydra owns this download, so the browser may drop
+                    // its own paused copy. Until this, it must not.
+                    ack.confirm();
+                    task
                 }
                 crate::extbus::ExtEvent::Stream(s) => {
                     // Not the capture dialog: a manifest cannot be probed

--- a/crates/hydra-gui/src/extbus.rs
+++ b/crates/hydra-gui/src/extbus.rs
@@ -112,10 +112,35 @@ pub struct ExtStream {
     pub size: Option<u64>,
 }
 
+/// Receipt for a capture: the socket thread answers the browser only once
+/// the UI thread has taken the download.
+///
+/// The extension CANCELS AND ERASES the browser's own copy when it sees
+/// `ok`, so that word has to mean "hydra owns this now". It used to mean
+/// "a message went onto a channel", and the difference is a lost file: an
+/// app that dies between the two (on Windows the browser kills the whole
+/// native-messaging job the moment the host answers) takes the download
+/// with it, having already told the browser to let go.
+#[derive(Clone, Debug)]
+pub struct Ack(std::sync::mpsc::Sender<()>);
+
+impl Ack {
+    /// Called from the UI thread once the item is in the download list.
+    pub fn confirm(&self) {
+        let _ = self.0.send(());
+    }
+}
+
+/// How long the socket thread waits for that receipt. Generous, because a
+/// cold start hands the capture over while `boot` is still running and the
+/// subscription that drains this channel only starts after it; a browser
+/// download stays paused meanwhile, and resumes untouched on timeout.
+const ACK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 #[derive(Clone, Debug)]
 pub enum ExtEvent {
     /// Single captured download -> Download File Info dialog.
-    Download(ExtDownload),
+    Download(ExtDownload, Ack),
     /// A manifest -> the stream-aware download path.
     Stream(Box<ExtStream>),
     /// "Download all links": many URLs -> the batch window.
@@ -467,8 +492,19 @@ fn dispatch(req: &serde_json::Value, trusted: bool) -> serde_json::Value {
                     dl.user_agent.as_deref().unwrap_or("-"),
                     dl.tab_url.as_deref().unwrap_or("-"),
                 ));
-                let _ = sender().send(ExtEvent::Download(dl));
-                (true, None)
+                let (tx, receipt) = std::sync::mpsc::channel();
+                let _ = sender().send(ExtEvent::Download(dl, Ack(tx)));
+                // Dropped sender (the event never reached the handler) ends
+                // the wait at once; a timeout means a wedged UI thread.
+                match receipt.recv_timeout(ACK_TIMEOUT) {
+                    Ok(()) => (true, None),
+                    Err(_) => {
+                        crate::log::warn(
+                            "extbus: capture was not taken up; handing it back to the browser",
+                        );
+                        (false, Some("hydra did not take the download"))
+                    }
+                }
             }
             _ => (false, Some("bad download request")),
         },
@@ -772,4 +808,39 @@ fn b64(data: &[u8]) -> String {
         });
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The whole capture hand-over rests on what `ok` means: the extension
+    /// cancels and ERASES the browser's own download when it sees it. So it
+    /// may only be said once the UI thread has the item — and must not be
+    /// said at all when the event is dropped on the floor, which is what a
+    /// dying app looks like from here.
+    #[test]
+    fn a_capture_is_acknowledged_only_once_the_app_takes_it() {
+        let mut rx = take_events().expect("the receiver is free in this test");
+        let req = serde_json::json!({"type": "download", "url": "https://example.invalid/f.zip"});
+        let ok = |reply: serde_json::Value| reply["ok"].as_bool().expect("ok flag");
+
+        let replying = {
+            let req = req.clone();
+            std::thread::spawn(move || dispatch(&req, true))
+        };
+        let Some(ExtEvent::Download(dl, ack)) = rx.blocking_recv() else {
+            panic!("a download event should have been queued");
+        };
+        assert_eq!(dl.url, "https://example.invalid/f.zip");
+        ack.confirm();
+        assert!(ok(replying.join().expect("dispatch thread")));
+
+        let replying = std::thread::spawn(move || dispatch(&req, true));
+        // Never confirmed: the receipt channel dies with the event, and the
+        // browser is told to keep the download rather than wait out the
+        // whole timeout.
+        drop(rx.blocking_recv());
+        assert!(!ok(replying.join().expect("dispatch thread")));
+    }
 }

--- a/crates/hydra-gui/src/log.rs
+++ b/crates/hydra-gui/src/log.rs
@@ -87,6 +87,29 @@ pub fn error(line: &str) {
     write(Level::Error, "ERROR", line);
 }
 
+/// Route panics into this log.
+///
+/// A release build is `windows_subsystem = "windows"` and is launched by the
+/// browser's native-messaging host with its stdio on the null device, so a
+/// panic message has nowhere to go: the app simply vanishes, and the bug
+/// report reads "it crashed" with an empty log box. The default hook still
+/// runs afterwards for the cases where a console does exist.
+pub fn catch_panics() {
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let where_ = info
+            .location()
+            .map(|l| format!("{}:{}", l.file(), l.line()))
+            .unwrap_or_else(|| "unknown location".into());
+        error(&format!(
+            "panic at {where_}: {}\n{}",
+            info.payload_as_str().unwrap_or("<non-string payload>"),
+            std::backtrace::Backtrace::force_capture()
+        ));
+        previous(info);
+    }));
+}
+
 /// Back-compat alias for the original single-level call sites.
 pub fn log(line: &str) {
     info(line);

--- a/crates/hydra-gui/src/main.rs
+++ b/crates/hydra-gui/src/main.rs
@@ -98,6 +98,11 @@ fn main() -> iced::Result {
         }
     }
 
+    // From here on a panic lands in the session log rather than on a
+    // stdout nobody sees (the app dir is known now, so it goes to the right
+    // profile's log).
+    log::catch_panics();
+
     // Single instance: if a running instance answers on the extbus
     // socket, hand it the spotlight (it opens its main window) and leave.
     // Two instances would fight over state.redb, the tray, and ipc.json —

--- a/crates/hydra-host/src/main.rs
+++ b/crates/hydra-host/src/main.rs
@@ -56,15 +56,45 @@ fn connect_once() -> Option<(TcpStream, String)> {
     Some((stream, token))
 }
 
-/// Detached spawn of a GUI binary; true when the process started.
-fn spawn_direct(program: std::ffi::OsString) -> bool {
-    std::process::Command::new(program)
-        .arg("--minimized")
+/// A minimized GUI launch, stdio detached from ours.
+fn gui_command(program: &std::ffi::OsStr) -> std::process::Command {
+    let mut cmd = std::process::Command::new(program);
+    cmd.arg("--minimized")
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-        .is_ok()
+        .stderr(std::process::Stdio::null());
+    cmd
+}
+
+/// Detached spawn of a GUI binary; true when the process started.
+///
+/// Windows: the browser runs a native-messaging host inside a JOB OBJECT and
+/// kills the job when the host exits — which, for the one-shot
+/// `sendNativeMessage` the extension calls us through, is the moment we
+/// answer. Every process we started goes with us, so the GUI launched for
+/// this very capture died seconds after starting, before any window of it
+/// appeared. `CREATE_BREAKAWAY_FROM_JOB` is what Mozilla and Chrome
+/// prescribe for children that must outlive the host; `DETACHED_PROCESS`
+/// keeps the GUI off the console the browser gave us.
+fn spawn_direct(program: std::ffi::OsString) -> bool {
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        const CREATE_BREAKAWAY_FROM_JOB: u32 = 0x0100_0000;
+        const DETACHED_PROCESS: u32 = 0x0000_0008;
+        if gui_command(&program)
+            .creation_flags(CREATE_BREAKAWAY_FROM_JOB | DETACHED_PROCESS)
+            .spawn()
+            .is_ok()
+        {
+            return true;
+        }
+        // A job created without JOB_OBJECT_LIMIT_BREAKAWAY_OK refuses the
+        // flag outright (ERROR_ACCESS_DENIED) rather than ignoring it. Fall
+        // back to an ordinary spawn — the pre-existing behaviour, and still
+        // the right answer on any browser that runs us outside a job.
+    }
+    gui_command(&program).spawn().is_ok()
 }
 
 /// Launch hydra-gui minimized: the capture dialog is the only surface that

--- a/crates/hydra-host/src/main.rs
+++ b/crates/hydra-host/src/main.rs
@@ -34,13 +34,19 @@ fn app_dir() -> PathBuf {
     }
 }
 
-/// (port, token) from ipc.json, if the file exists and parses.
-fn read_ipc() -> Option<(u16, String)> {
-    let text = std::fs::read_to_string(app_dir().join("ipc.json")).ok()?;
-    let v: serde_json::Value = serde_json::from_str(&text).ok()?;
-    let port = v.get("port")?.as_u64()? as u16;
+/// (port, token) out of an ipc.json body. A file from a crashed run, a
+/// half-written one, or one from a build that spelled the fields
+/// differently all read as "no instance" rather than as a bad address.
+fn parse_ipc(text: &str) -> Option<(u16, String)> {
+    let v: serde_json::Value = serde_json::from_str(text).ok()?;
+    let port = u16::try_from(v.get("port")?.as_u64()?).ok()?;
     let token = v.get("token")?.as_str()?.to_string();
     Some((port, token))
+}
+
+/// (port, token) from ipc.json, if the file exists and parses.
+fn read_ipc() -> Option<(u16, String)> {
+    parse_ipc(&std::fs::read_to_string(app_dir().join("ipc.json")).ok()?)
 }
 
 /// Try to connect to the GUI right now. The file may be stale from a
@@ -236,5 +242,175 @@ fn main() {
             Some(r) => write_frame(&mut stdout, r.trim().as_bytes()),
             None => write_frame(&mut stdout, &error_reply("hydra is not running")),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::TcpListener;
+
+    /// ipc.json outlives the instance that wrote it, so the file alone is
+    /// never the answer to "is hydra running": the port has to accept a
+    /// connection, or some unrelated process that inherited the number
+    /// would be handed the user's downloads.
+    ///
+    /// Sets HOME/APPDATA, which `app_dir` reads and nothing else in this
+    /// binary does.
+    #[test]
+    fn a_stale_ipc_file_is_not_mistaken_for_a_running_app() {
+        let home = std::env::temp_dir().join(format!("hydra-host-{}", std::process::id()));
+        let cfg = home.join(".config");
+        std::fs::create_dir_all(cfg.join("hydra")).expect("test app dir");
+        std::env::set_var("HOME", &home);
+        std::env::set_var("APPDATA", &cfg);
+        let publish = |port: u16| {
+            std::fs::write(
+                app_dir().join("ipc.json"),
+                format!(r#"{{"port":{port},"token":"s3cret"}}"#),
+            )
+            .expect("write ipc.json");
+        };
+
+        // A port nobody is listening on any more: the file is what a
+        // crashed instance leaves behind.
+        let dead = {
+            let l = TcpListener::bind(("127.0.0.1", 0)).expect("free port");
+            l.local_addr().expect("address").port()
+        };
+        publish(dead);
+        assert!(
+            connect(false).is_none(),
+            "a stale file must not read as a running app"
+        );
+
+        let live = TcpListener::bind(("127.0.0.1", 0)).expect("loopback listener");
+        publish(live.local_addr().expect("address").port());
+        let (_stream, token) = connect(false).expect("a listening instance is reachable");
+        assert_eq!(token, "s3cret", "the token travels with the connection");
+
+        let _ = std::fs::remove_dir_all(&home);
+    }
+
+    /// The framing is the whole contract with the browser: four little-endian
+    /// bytes, then exactly that many bytes of JSON.
+    #[test]
+    fn a_frame_survives_the_round_trip() {
+        let payload = br#"{"type":"download","url":"https://example.invalid/f.zip"}"#;
+        let mut wire = Vec::new();
+        write_frame(&mut wire, payload);
+
+        assert_eq!(&wire[..4], &(payload.len() as u32).to_le_bytes());
+        assert_eq!(read_frame(&mut &wire[..]).as_deref(), Some(&payload[..]));
+    }
+
+    /// Anything the browser could not have sent ends the session instead of
+    /// being guessed at — the browser then respawns us with a clean stream.
+    #[test]
+    fn a_frame_the_browser_could_not_have_sent_is_refused() {
+        let framed = |len: u32, body: &[u8]| {
+            let mut v = len.to_le_bytes().to_vec();
+            v.extend_from_slice(body);
+            v
+        };
+
+        assert_eq!(read_frame(&mut &[][..]), None, "clean EOF");
+        assert_eq!(read_frame(&mut &[0u8, 1][..]), None, "half a length");
+        assert_eq!(read_frame(&mut &framed(0, b"")[..]), None, "empty message");
+        assert_eq!(
+            read_frame(&mut &framed(64 * 1024 * 1024 + 1, b"")[..]),
+            None,
+            "a length no legitimate message has"
+        );
+        assert_eq!(
+            read_frame(&mut &framed(8, b"short")[..]),
+            None,
+            "body shorter than its own length"
+        );
+    }
+
+    /// ipc.json is the only thing standing between us and connecting to a
+    /// port some unrelated process now owns, so a file that does not name a
+    /// real endpoint has to read as "no instance".
+    #[test]
+    fn ipc_json_answers_only_when_it_names_a_real_endpoint() {
+        assert_eq!(
+            parse_ipc(r#"{"port":50726,"token":"cafe","ws_port":6799,"pid":42}"#),
+            Some((50726, "cafe".to_string()))
+        );
+        for bad in [
+            r#"{"port":50726}"#,                  // no token
+            r#"{"token":"cafe"}"#,                // no port
+            r#"{"port":"50726","token":"cafe"}"#, // port as a string
+            r#"{"port":70000,"token":"cafe"}"#,   // beyond a port number
+            r#"{"port":50726,"token":7}"#,        // token as a number
+            "{\"port\":50726,",                   // half-written file
+            "",
+        ] {
+            assert_eq!(parse_ipc(bad), None, "should be unusable: {bad}");
+        }
+    }
+
+    /// The token lives in a file only this user can read; the browser never
+    /// sees it and never sends it. Stamping it on is this process's whole
+    /// reason for existing.
+    #[test]
+    fn a_request_is_stamped_with_the_token_the_browser_never_sees() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("loopback listener");
+        let addr = listener.local_addr().expect("listener address");
+        let gui = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("the host connects");
+            let mut out = stream.try_clone().expect("write half");
+            let mut line = String::new();
+            BufReader::new(stream)
+                .read_line(&mut line)
+                .expect("one request line");
+            writeln!(out, r#"{{"ok":true,"capture":true}}"#).expect("reply");
+            line
+        });
+
+        let mut conn = (
+            TcpStream::connect(addr).expect("connect to the fake gui"),
+            "s3cret".to_string(),
+        );
+        let mut req =
+            serde_json::json!({"type": "download", "url": "https://example.invalid/f.zip"});
+        assert!(req.get("token").is_none(), "the browser sends no token");
+
+        let reply = round_trip(&mut conn, &mut req).expect("a reply line");
+        assert_eq!(reply.trim(), r#"{"ok":true,"capture":true}"#);
+
+        let on_the_wire: serde_json::Value =
+            serde_json::from_str(&gui.join().expect("gui thread")).expect("json request");
+        assert_eq!(on_the_wire["token"], "s3cret");
+        assert_eq!(on_the_wire["url"], "https://example.invalid/f.zip");
+    }
+
+    /// The browser gets a JSON object even when there is nothing to talk to;
+    /// the extension reads `ok` off it and keeps its own download.
+    #[test]
+    fn an_unreachable_app_still_answers_in_json() {
+        let reply: serde_json::Value =
+            serde_json::from_slice(&error_reply("hydra is not running")).expect("json");
+        assert_eq!(reply["ok"], false);
+        assert_eq!(reply["error"], "hydra is not running");
+    }
+
+    /// `spawn_direct` reports whether a process actually started — that is
+    /// what `launch_gui` walks its candidate paths on. The current test
+    /// binary stands in for the GUI: it exists on every platform this
+    /// builds for, and exits immediately on an argument it has no test for.
+    #[test]
+    fn a_gui_launch_reports_whether_the_process_started() {
+        let me = std::env::current_exe().expect("test binary path");
+        assert!(spawn_direct(me.into_os_string()), "a real program starts");
+        assert!(
+            !spawn_direct(
+                std::env::temp_dir()
+                    .join("hydra-gui-that-is-not-here")
+                    .into_os_string()
+            ),
+            "a missing program does not"
+        );
     }
 }

--- a/extensions/chrome/background.js
+++ b/extensions/chrome/background.js
@@ -373,9 +373,10 @@ function captureEligible(item, state) {
 }
 
 // Freeze the download the moment it exists (downloads.pause in onCreated).
-// Pausing is reversible where cancelling is not: small files
+// On CHROMIUM pausing is reversible where cancelling is not: small files
 // cannot slip through by finishing early, and signed one-shot URLs keep
-// working because we never have to re-request them.
+// working because we never have to re-request them. Gecko does not park at
+// all — see the listener registration below for why.
 async function parkDownload(item) {
   const state = await getState();
   if (!captureEligible(item, state)) return;
@@ -386,11 +387,16 @@ async function parkDownload(item) {
   }
 }
 
-async function decideCapture(item) {
+// `parked` says whether the browser's own download is being held for us, and
+// therefore whether there is anything to hand back. Resuming one that was
+// never parked is not harmless: on Gecko it throws, and the throw used to be
+// swallowed next to a download that had already been cancelled.
+async function decideCapture(item, parked) {
   const state = await getState();
   const url = item.finalUrl || item.url;
 
   const giveBack = async () => {
+    if (!parked) return;
     try {
       await chrome.downloads.resume(item.id);
     } catch {}
@@ -410,11 +416,12 @@ async function decideCapture(item) {
   });
 
   if (reply && reply.ok) {
-    // Hydra owns it now; drop the browser's paused copy.
+    // Hydra owns it now; drop the browser's copy. Erasing only after the
+    // cancel really took: a download that finished before the answer came
+    // back is already a file on disk, and erasing its record would leave
+    // that file with nothing pointing at it.
     try {
       await chrome.downloads.cancel(item.id);
-    } catch {}
-    try {
       await chrome.downloads.erase({ id: item.id });
     } catch {}
   } else {
@@ -435,17 +442,22 @@ if (onDeterminingFilename) {
   chrome.downloads.onCreated.addListener((item) => parkDownload(item));
   onDeterminingFilename.addListener((item, suggest) => {
     suggest();
-    decideCapture(item);
+    decideCapture(item, true);
   });
 } else if (chrome.downloads?.onCreated) {
-  // Firefox: no onDeterminingFilename, but `filename` is already resolved on
-  // the create event. Park and decide in ONE sequential listener — two
-  // listeners on the same event run concurrently, and the decision would
-  // race the pause it depends on.
-  chrome.downloads.onCreated.addListener(async (item) => {
-    await parkDownload(item);
-    await decideCapture(item);
-  });
+  // Gecko: NOTHING is parked. `downloads.pause()` there is
+  // `download.cancel()`, and `downloads.resume()` is gated on `canResume`,
+  // which needs `hasPartialData` — false for a download still at byte 0.
+  // Parking on creation is therefore a one-way trip: every download we
+  // then handed back (the wrong file type, a skipped site, Hydra saying
+  // no) stayed "Canceled" forever, and the failed resume was swallowed.
+  //
+  // So the browser keeps its own transfer running while we decide. It is
+  // only cancelled once Hydra has actually taken the file, and a refusal
+  // costs nothing but the seconds of bytes the browser had already
+  // fetched. `filename` is resolved on the create event here, so the whole
+  // decision can be made from it.
+  chrome.downloads.onCreated.addListener((item) => decideCapture(item, false));
 }
 // Safari has no downloads API at all; there the extension is menus +
 // selection pill + sniffing only.

--- a/extensions/chrome/manifest.json
+++ b/extensions/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hydra Download Manager Integration",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A browser integration for Hydra: automatic download capture, right-click downloads, and media/HLS/DASH stream sniffing.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAt7NVgqBOTaCTKcon/gTK0M4VxY4ZKcyh0pWTVQoWfjJrJlTvRHaWFxE4ZbIj+88zNKJBxVa6uMdQKtK2V+NaPYR1NTYyTDh75UErRI+mx5RXa5c2kiwudl2jwHPsYcUU9NPMI4FwqVFaxEetvIS9J91/3ze5l+FbsZDF0Yvc9uR1dYNnnc//nGg1R+uL0/wus4INeccd9COj10+Aka2SeBkvrVlLs63AMFMkPpN9iIBwyhgs01bulVRFbvHK9m/TizLfthMHAyMCkUdCkZr6gEZbYbwNwGwKCUIswomoiVRgZx/FBFYrh6cRlfoLQZUbS7kFTShpfjm+zEGBkWQ3yQIDAQAB",
   "minimum_chrome_version": "116",

--- a/extensions/firefox/manifest.json
+++ b/extensions/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hydra Download Manager Integration",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A browser integration for Hydra: automatic download capture, right-click downloads, and media/HLS/DASH stream sniffing.",
   "browser_specific_settings": {
     "gecko": {

--- a/extensions/safari/Resources/background.js
+++ b/extensions/safari/Resources/background.js
@@ -373,9 +373,10 @@ function captureEligible(item, state) {
 }
 
 // Freeze the download the moment it exists (downloads.pause in onCreated).
-// Pausing is reversible where cancelling is not: small files
+// On CHROMIUM pausing is reversible where cancelling is not: small files
 // cannot slip through by finishing early, and signed one-shot URLs keep
-// working because we never have to re-request them.
+// working because we never have to re-request them. Gecko does not park at
+// all — see the listener registration below for why.
 async function parkDownload(item) {
   const state = await getState();
   if (!captureEligible(item, state)) return;
@@ -386,11 +387,16 @@ async function parkDownload(item) {
   }
 }
 
-async function decideCapture(item) {
+// `parked` says whether the browser's own download is being held for us, and
+// therefore whether there is anything to hand back. Resuming one that was
+// never parked is not harmless: on Gecko it throws, and the throw used to be
+// swallowed next to a download that had already been cancelled.
+async function decideCapture(item, parked) {
   const state = await getState();
   const url = item.finalUrl || item.url;
 
   const giveBack = async () => {
+    if (!parked) return;
     try {
       await chrome.downloads.resume(item.id);
     } catch {}
@@ -410,11 +416,12 @@ async function decideCapture(item) {
   });
 
   if (reply && reply.ok) {
-    // Hydra owns it now; drop the browser's paused copy.
+    // Hydra owns it now; drop the browser's copy. Erasing only after the
+    // cancel really took: a download that finished before the answer came
+    // back is already a file on disk, and erasing its record would leave
+    // that file with nothing pointing at it.
     try {
       await chrome.downloads.cancel(item.id);
-    } catch {}
-    try {
       await chrome.downloads.erase({ id: item.id });
     } catch {}
   } else {
@@ -435,17 +442,22 @@ if (onDeterminingFilename) {
   chrome.downloads.onCreated.addListener((item) => parkDownload(item));
   onDeterminingFilename.addListener((item, suggest) => {
     suggest();
-    decideCapture(item);
+    decideCapture(item, true);
   });
 } else if (chrome.downloads?.onCreated) {
-  // Firefox: no onDeterminingFilename, but `filename` is already resolved on
-  // the create event. Park and decide in ONE sequential listener — two
-  // listeners on the same event run concurrently, and the decision would
-  // race the pause it depends on.
-  chrome.downloads.onCreated.addListener(async (item) => {
-    await parkDownload(item);
-    await decideCapture(item);
-  });
+  // Gecko: NOTHING is parked. `downloads.pause()` there is
+  // `download.cancel()`, and `downloads.resume()` is gated on `canResume`,
+  // which needs `hasPartialData` — false for a download still at byte 0.
+  // Parking on creation is therefore a one-way trip: every download we
+  // then handed back (the wrong file type, a skipped site, Hydra saying
+  // no) stayed "Canceled" forever, and the failed resume was swallowed.
+  //
+  // So the browser keeps its own transfer running while we decide. It is
+  // only cancelled once Hydra has actually taken the file, and a refusal
+  // costs nothing but the seconds of bytes the browser had already
+  // fetched. `filename` is resolved on the create event here, so the whole
+  // decision can be made from it.
+  chrome.downloads.onCreated.addListener((item) => decideCapture(item, false));
 }
 // Safari has no downloads API at all; there the extension is menus +
 // selection pill + sniffing only.

--- a/extensions/safari/Resources/manifest.json
+++ b/extensions/safari/Resources/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hydra Download Manager Integration",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "description": "A browser integration for Hydra: right-click downloads, link selection, and media/HLS/DASH stream sniffing.",
   "browser_specific_settings": {
     "safari": {

--- a/extensions/safari/manifest.json
+++ b/extensions/safari/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hydra Download Manager Integration",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A browser integration for Hydra: right-click downloads, link selection, and media/HLS/DASH stream sniffing.",
   "browser_specific_settings": {
     "safari": {

--- a/extensions/tests/capture.test.mjs
+++ b/extensions/tests/capture.test.mjs
@@ -18,7 +18,7 @@ const check = (label, cond, extra = "") => {
 };
 const tick = (n = 3) => new Promise((r) => { let i = 0; const f = () => (++i >= n ? r() : setImmediate(f)); setImmediate(f); });
 
-function build({ hydraReply = { ok: true }, store = {} } = {}) {
+function build({ hydraReply = { ok: true }, store = {}, gecko = false } = {}) {
   const sent = [];          // messages that reached "Hydra"
   const calls = [];         // downloads API calls
   const listeners = {};
@@ -50,7 +50,11 @@ function build({ hydraReply = { ok: true }, store = {} } = {}) {
       setBadgeBackgroundColor: async () => {}, setBadgeText: async () => {}, setTitle: async () => {},
     },
     downloads: {
-      onCreated, onDeterminingFilename: onDetermining,
+      onCreated,
+      // Gecko has no onDeterminingFilename at all — the capture path keys
+      // off its absence, so a mock that always offers it can only ever test
+      // the Chromium half.
+      ...(gecko ? {} : { onDeterminingFilename: onDetermining }),
       pause: async (id) => calls.push(["pause", id]),
       resume: async (id) => calls.push(["resume", id]),
       cancel: async (id) => calls.push(["cancel", id]),
@@ -178,6 +182,39 @@ function build({ hydraReply = { ok: true }, store = {} } = {}) {
   h.onDetermining.fire(item, () => {}); await tick(8);
   check("fallback: a refused hand-off resumes the browser download", h.calls.some(([c]) => c === "resume"));
   check("fallback: the paused copy is not cancelled", !h.calls.some(([c]) => c === "cancel"));
+}
+
+// ------------------------------------------------ 5b. the Gecko capture path
+//
+// `downloads.pause()` on Gecko is `download.cancel()`, and `resume()` needs
+// partial data a download at byte 0 has none of. So nothing there may be
+// parked speculatively: a download the extension touches and hands back is
+// stuck "Canceled" for good.
+{
+  const h = build({ gecko: true });
+  await tick(12);
+  const item = { id: 51, url: "https://cdn.example/photo.png", filename: "photo.png", mime: "image/png" };
+  h.onCreated.fire(item); await tick(8);
+  check("gecko: an unlisted type is never touched",
+    h.calls.length === 0 && !h.sent.some((m) => m.type === "download"), JSON.stringify(h.calls));
+}
+{
+  const h = build({ gecko: true });
+  await tick(12);
+  const item = { id: 52, url: "https://cdn.example/pack.zip", filename: "pack.zip", mime: "application/zip", totalBytes: 5e6 };
+  h.onCreated.fire(item); await tick(10);
+  check("gecko: a matching type reaches Hydra without being paused",
+    h.sent.some((m) => m.type === "download") && !h.calls.some(([c]) => c === "pause"), JSON.stringify(h.calls));
+  check("gecko: the browser's copy is cancelled once Hydra has it",
+    h.calls.some(([c]) => c === "cancel") && h.calls.some(([c]) => c === "erase"));
+}
+{
+  const h = build({ gecko: true, hydraReply: { ok: false, error: "nope" } });
+  await tick(12);
+  const item = { id: 53, url: "https://cdn.example/pack.zip", filename: "pack.zip", mime: "application/zip" };
+  h.onCreated.fire(item); await tick(10);
+  check("gecko: a refused hand-off leaves the browser download running",
+    !h.calls.some(([c]) => c === "cancel") && !h.calls.some(([c]) => c === "resume"), JSON.stringify(h.calls));
 }
 
 // ------------------------------------------- 6. right-click a link / media


### PR DESCRIPTION
Firefox and Chrome run a native-messaging host inside a job object and kill the job when the host exits — for the one-shot sendNativeMessage the extension uses, that is the moment the host answers. The hydra-gui it had just launched for the capture was killed with it, seconds after starting and before any window appeared, while the extension had already cancelled and erased the browser's own copy on the strength of the reply, so the download was lost outright.

- hydra-host spawns the GUI with CREATE_BREAKAWAY_FROM_JOB, as Mozilla and Chrome prescribe for children that must outlive the host, falling back to a plain spawn where a job refuses breakaway.
- extbus acknowledges a capture only once the UI thread has the item in the download list, so "ok" means hydra owns it; anything else hands the download back to the browser, which resumes it untouched.
- panics land in gui.log with a backtrace — a windows_subsystem="windows" build launched with its stdio on the null device has nowhere else to put them, which is why this report came with an empty log box.

- Resolve #148
- Resolve #150