### PR TITLE
Fix stop the NSIS installer from wiping a long user PATH

### DIFF
--- a/scripts/windows/hydra-installer.nsi
+++ b/scripts/windows/hydra-installer.nsi
@@ -262,13 +262,26 @@ Section "Command-Line Tool (hydra, hya) + PATH" SEC_CLI
   ; unexpanded, and write back in the value's original REG_EXPAND_SZ kind.
   ; If PowerShell cannot start, the step is skipped: a missing PATH entry
   ; is recoverable, a wiped PATH is not.
+  ;
+  ; nsExec::Exec (not ExecToStack) pushes a single value, and comparing it
+  ; as a string keeps "error"/"timeout" from being mistaken for success.
+  ; The environment-change broadcast is done here on success, so the
+  ; helper needs no Add-Type (no csc.exe round trip, and it stays usable
+  ; under ConstrainedLanguage mode).
+  StrCpy $0 "$INSTDIR" "" -1        ; normalize $INSTDIR: drop a trailing
+  StrCmp $0 "\" 0 +3                ; backslash so the helper sees the same
+  StrCpy $0 "$INSTDIR" -1           ; spelling the uninstaller will strip
+  Goto +2
+  StrCpy $0 "$INSTDIR"
   InitPluginsDir
   File "/oname=$PLUGINSDIR\set-user-path.ps1" "set-user-path.ps1"
-  nsExec::ExecToStack '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -File "$PLUGINSDIR\set-user-path.ps1" -Action Append -Dir "$INSTDIR"'
+  nsExec::Exec '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -File "$PLUGINSDIR\set-user-path.ps1" -Action Append -Dir "$0"'
   Pop $0
-  StrCmp $0 "error" ps_path_skip   ; PowerShell itself did not start
-  Pop $1                           ; script output (unused)
-  IntCmp $0 0 ps_path_done ps_path_skip ps_path_skip
+  StrCmp $0 "0" 0 ps_path_skip
+  ; Tell running shells/Explorer the environment changed; new terminals
+  ; pick it up immediately, already-open ones still need a restart.
+  SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
+  Goto ps_path_done
 ps_path_skip:
   DetailPrint "user PATH not updated (set-user-path.ps1 exit $0)"
 ps_path_done:
@@ -430,14 +443,21 @@ Section "Uninstall"
 
   ; Strip $INSTDIR out of the per-user PATH. Same PowerShell helper as the
   ; installer: with NSIS_MAX_STRLEN at 1024, a longer PATH reads back empty
-  ; and writing it out here used to wipe the whole value.
+  ; and writing it out here used to wipe the whole value. nsExec::Exec
+  ; pushes a single value, compared as a string so "error"/"timeout" cannot
+  ; pass for success; the broadcast runs here on success.
+  StrCpy $0 "$INSTDIR" "" -1        ; normalize $INSTDIR: drop a trailing
+  StrCmp $0 "\" 0 +3                ; backslash so both directions see the
+  StrCpy $0 "$INSTDIR" -1           ; same spelling
+  Goto +2
+  StrCpy $0 "$INSTDIR"
   InitPluginsDir
   File "/oname=$PLUGINSDIR\set-user-path.ps1" "set-user-path.ps1"
-  nsExec::ExecToStack '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -File "$PLUGINSDIR\set-user-path.ps1" -Action Remove -Dir "$INSTDIR"'
+  nsExec::Exec '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -File "$PLUGINSDIR\set-user-path.ps1" -Action Remove -Dir "$0"'
   Pop $0
-  StrCmp $0 "error" ps_unpath_skip ; PowerShell itself did not start
-  Pop $1                           ; script output (unused)
-  IntCmp $0 0 ps_unpath_done ps_unpath_skip ps_unpath_skip
+  StrCmp $0 "0" 0 ps_unpath_skip
+  SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
+  Goto ps_unpath_done
 ps_unpath_skip:
   DetailPrint "user PATH not updated (set-user-path.ps1 exit $0)"
 ps_unpath_done:

--- a/scripts/windows/hydra-installer.nsi
+++ b/scripts/windows/hydra-installer.nsi
@@ -135,8 +135,6 @@ VIAddVersionKey "LegalCopyright"  "(C) 2026 ${PUBLISHER}. GPL-3.0-or-later."
 !include "StrFunc.nsh"
 !include "Sections.nsh"
 ${Using:StrFunc} StrRep
-${Using:StrFunc} StrStr
-${Using:StrFunc} UnStrRep
 
 ;--------------------------------
 ; UI
@@ -252,21 +250,28 @@ Section "Command-Line Tool (hydra, hya) + PATH" SEC_CLI
 
   ; Append $INSTDIR to the per-user PATH (HKCU\Environment) so `hydra`,
   ; `hydra-gui`, and `hydra-host` resolve in cmd, PowerShell, and any
-  ; terminal. REG_EXPAND_SZ so pre-existing %VAR% entries keep expanding.
-  ReadRegStr $0 HKCU "Environment" "Path"
-  ${StrStr} $1 "$0" "$INSTDIR"
-  StrCmp $1 "" 0 path_done          ; already present -> skip
-  StrCmp $0 "" 0 path_append
-  StrCpy $0 "$INSTDIR"              ; PATH was empty/absent
-  Goto path_write
-path_append:
-  StrCpy $0 "$0;$INSTDIR"
-path_write:
-  WriteRegExpandStr HKCU "Environment" "Path" $0
-  ; Tell running shells/Explorer the environment changed; new terminals
-  ; pick it up immediately, already-open ones still need a restart.
-  SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
-path_done:
+  ; terminal.
+  ;
+  ; The read/modify/write runs in PowerShell rather than ReadRegStr +
+  ; WriteRegExpandStr here: NSIS runtime strings cap at NSIS_MAX_STRLEN
+  ; (1024 characters in official builds), so a longer PATH reads back EMPTY
+  ; and this block used to take its "PATH was empty" branch and REPLACE the
+  ; whole value with $INSTDIR, wiping every existing entry (the uninstaller
+  ; correspondingly wrote an empty PATH). The helper script uses .NET
+  ; registry APIs, which have no length limit, keep %VAR% entries
+  ; unexpanded, and write back in the value's original REG_EXPAND_SZ kind.
+  ; If PowerShell cannot start, the step is skipped: a missing PATH entry
+  ; is recoverable, a wiped PATH is not.
+  InitPluginsDir
+  File "/oname=$PLUGINSDIR\set-user-path.ps1" "set-user-path.ps1"
+  nsExec::ExecToStack '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -File "$PLUGINSDIR\set-user-path.ps1" -Action Append -Dir "$INSTDIR"'
+  Pop $0
+  StrCmp $0 "error" ps_path_skip   ; PowerShell itself did not start
+  Pop $1                           ; script output (unused)
+  IntCmp $0 0 ps_path_done ps_path_skip ps_path_skip
+ps_path_skip:
+  DetailPrint "user PATH not updated (set-user-path.ps1 exit $0)"
+ps_path_done:
 SectionEnd
 
 Section "Browser Extensions" SEC_EXT
@@ -423,13 +428,19 @@ Section "Uninstall"
   DeleteRegKey HKCU "Software\Vivaldi\NativeMessagingHosts\${HOST_NAME}"
   DeleteRegKey HKCU "Software\Mozilla\NativeMessagingHosts\${HOST_NAME}"
 
-  ; Strip $INSTDIR out of the per-user PATH (all three separator shapes).
-  ReadRegStr $0 HKCU "Environment" "Path"
-  ${UnStrRep} $0 "$0" ";$INSTDIR" ""
-  ${UnStrRep} $0 "$0" "$INSTDIR;" ""
-  ${UnStrRep} $0 "$0" "$INSTDIR"  ""
-  WriteRegExpandStr HKCU "Environment" "Path" $0
-  SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
+  ; Strip $INSTDIR out of the per-user PATH. Same PowerShell helper as the
+  ; installer: with NSIS_MAX_STRLEN at 1024, a longer PATH reads back empty
+  ; and writing it out here used to wipe the whole value.
+  InitPluginsDir
+  File "/oname=$PLUGINSDIR\set-user-path.ps1" "set-user-path.ps1"
+  nsExec::ExecToStack '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -File "$PLUGINSDIR\set-user-path.ps1" -Action Remove -Dir "$INSTDIR"'
+  Pop $0
+  StrCmp $0 "error" ps_unpath_skip ; PowerShell itself did not start
+  Pop $1                           ; script output (unused)
+  IntCmp $0 0 ps_unpath_done ps_unpath_skip ps_unpath_skip
+ps_unpath_skip:
+  DetailPrint "user PATH not updated (set-user-path.ps1 exit $0)"
+ps_unpath_done:
 
   Delete "$INSTDIR\hydra-gui.exe"
   Delete "$INSTDIR\hydra.exe"

--- a/scripts/windows/set-user-path.ps1
+++ b/scripts/windows/set-user-path.ps1
@@ -11,9 +11,11 @@
 #   powershell -NoProfile -ExecutionPolicy Bypass -File set-user-path.ps1 -Action Append -Dir "C:\some\dir"
 #   powershell -NoProfile -ExecutionPolicy Bypass -File set-user-path.ps1 -Action Remove -Dir "C:\some\dir"
 #
-# The directory is matched case-insensitively and without trailing
-# backslashes, in either direction: appending a directory that is already
-# present in another spelling is a no-op rather than a duplicate.
+# The change is minimal by design: anything already in the value keeps its
+# position and spelling. Append is a no-op when the directory is present in
+# any spelling (case, quoting, trailing backslash); Remove is a no-op when it
+# is absent. Running processes are notified by the installer itself (a plain
+# SendMessage there) rather than from here, so this script needs no Add-Type.
 #
 # Exit codes: 0 = the PATH is in the wanted state (written or already was),
 # 1 = something failed and nothing was written.
@@ -24,10 +26,13 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+$key = $null
 try {
   if ([string]::IsNullOrWhiteSpace($Dir)) { exit 1 }
 
-  $key = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $true)
+  # CreateSubKey, not OpenSubKey: an absent Environment key is created for
+  # writing, mirroring what WriteRegExpandStr did.
+  $key = [Microsoft.Win32.Registry]::CurrentUser.CreateSubKey('Environment')
   if (-not $key) { exit 1 }
 
   # Read the raw value unexpanded so %VAR% entries round-trip unchanged, and
@@ -38,31 +43,38 @@ try {
   $kind = [Microsoft.Win32.RegistryValueKind]::ExpandString
   try { $kind = $key.GetValueKind('Path') } catch { }
 
-  $dirNorm = $Dir.TrimEnd('\').ToLowerInvariant()
+  $dirNorm = $Dir.Trim().Trim('"').TrimEnd('\').ToLowerInvariant()
   $entries = @()
   if ($current -ne '') {
-    $entries = @($current -split ';' | Where-Object { $_ -ne '' })
+    $entries = @($current -split ';' | Where-Object { $_.Trim() -ne '' })
   }
-  $kept = @($entries | Where-Object { $_.TrimEnd('\').ToLowerInvariant() -ne $dirNorm })
-  if ($Action -eq 'Append') { $kept += $Dir }
 
-  $new = ($kept -join ';')
-  if ($new -eq $current) { exit 0 }
+  $present = $entries | Where-Object {
+    $_.Trim().Trim('"').TrimEnd('\').ToLowerInvariant() -eq $dirNorm
+  }
+
+  if ($Action -eq 'Append') {
+    # Already present in any spelling: keep the user's own ordering and
+    # formatting untouched rather than rewriting the value.
+    if ($present) { exit 0 }
+    $new = if ($current -ne '') {
+      if ($current.EndsWith(';')) { "$current$Dir" } else { "$current;$Dir" }
+    } else {
+      $Dir
+    }
+  } else {
+    # Not present: nothing to remove, leave the value exactly as it is.
+    if (-not $present) { exit 0 }
+    $kept = @($entries | Where-Object {
+      $_.Trim().Trim('"').TrimEnd('\').ToLowerInvariant() -ne $dirNorm
+    })
+    $new = ($kept -join ';')
+  }
 
   $key.SetValue('Path', $new, $kind)
-
-  # Registry writes do not notify running processes. Tell Explorer and friends
-  # so newly started shells pick the change up without a logoff; failures
-  # here must not turn a successful write into a reported error.
-  try {
-    Add-Type -Namespace Win32 -Name HydraPathBroadcast -MemberDefinition @'
-[System.Runtime.InteropServices.DllImport("user32.dll", SetLastError = true)]
-public static extern System.IntPtr SendMessageTimeout(System.IntPtr hWnd, uint Msg, System.UIntPtr wParam, string lParam, uint fuFlags, uint uTimeout, out System.UIntPtr lpdwResult);
-'@
-    $smResult = [UIntPtr]::Zero
-    [Win32.HydraPathBroadcast]::SendMessageTimeout([IntPtr]0xFFFF, 0x1A, [UIntPtr]::Zero, 'Environment', 2, 5000, [ref]$smResult) | Out-Null
-  } catch { }
 } catch {
   exit 1
+} finally {
+  if ($key) { $key.Close() }
 }
 exit 0

--- a/scripts/windows/set-user-path.ps1
+++ b/scripts/windows/set-user-path.ps1
@@ -1,0 +1,68 @@
+# Append or remove one directory from the per-user PATH (HKCU\Environment\Path).
+#
+# Called by hydra-installer.nsi instead of doing the registry work there,
+# because NSIS runtime strings cap at NSIS_MAX_STRLEN (1024 characters in
+# official builds). A longer PATH comes back EMPTY from ReadRegStr, which made
+# the installer's old read-append-write block replace the whole value with
+# $INSTDIR, and made the uninstaller write an empty PATH. .NET registry APIs
+# have no length limit; reading unexpanded keeps %VAR%-style entries intact.
+#
+# Usage:
+#   powershell -NoProfile -ExecutionPolicy Bypass -File set-user-path.ps1 -Action Append -Dir "C:\some\dir"
+#   powershell -NoProfile -ExecutionPolicy Bypass -File set-user-path.ps1 -Action Remove -Dir "C:\some\dir"
+#
+# The directory is matched case-insensitively and without trailing
+# backslashes, in either direction: appending a directory that is already
+# present in another spelling is a no-op rather than a duplicate.
+#
+# Exit codes: 0 = the PATH is in the wanted state (written or already was),
+# 1 = something failed and nothing was written.
+
+param(
+  [Parameter(Mandatory = $true)][ValidateSet('Append', 'Remove')][string]$Action,
+  [Parameter(Mandatory = $true)][string]$Dir
+)
+
+$ErrorActionPreference = 'Stop'
+try {
+  if ([string]::IsNullOrWhiteSpace($Dir)) { exit 1 }
+
+  $key = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey('Environment', $true)
+  if (-not $key) { exit 1 }
+
+  # Read the raw value unexpanded so %VAR% entries round-trip unchanged, and
+  # write back in the value's own kind (Path is REG_EXPAND_SZ by default; an
+  # absent value is created as REG_EXPAND_SZ, like WriteRegExpandStr did).
+  $opts = [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames
+  $current = [string]$key.GetValue('Path', '', $opts)
+  $kind = [Microsoft.Win32.RegistryValueKind]::ExpandString
+  try { $kind = $key.GetValueKind('Path') } catch { }
+
+  $dirNorm = $Dir.TrimEnd('\').ToLowerInvariant()
+  $entries = @()
+  if ($current -ne '') {
+    $entries = @($current -split ';' | Where-Object { $_ -ne '' })
+  }
+  $kept = @($entries | Where-Object { $_.TrimEnd('\').ToLowerInvariant() -ne $dirNorm })
+  if ($Action -eq 'Append') { $kept += $Dir }
+
+  $new = ($kept -join ';')
+  if ($new -eq $current) { exit 0 }
+
+  $key.SetValue('Path', $new, $kind)
+
+  # Registry writes do not notify running processes. Tell Explorer and friends
+  # so newly started shells pick the change up without a logoff; failures
+  # here must not turn a successful write into a reported error.
+  try {
+    Add-Type -Namespace Win32 -Name HydraPathBroadcast -MemberDefinition @'
+[System.Runtime.InteropServices.DllImport("user32.dll", SetLastError = true)]
+public static extern System.IntPtr SendMessageTimeout(System.IntPtr hWnd, uint Msg, System.UIntPtr wParam, string lParam, uint fuFlags, uint uTimeout, out System.UIntPtr lpdwResult);
+'@
+    $smResult = [UIntPtr]::Zero
+    [Win32.HydraPathBroadcast]::SendMessageTimeout([IntPtr]0xFFFF, 0x1A, [UIntPtr]::Zero, 'Environment', 2, 5000, [ref]$smResult) | Out-Null
+  } catch { }
+} catch {
+  exit 1
+}
+exit 0


### PR DESCRIPTION
Fixes #161

## What

The installer and uninstaller no longer read/modify the per-user PATH with
`ReadRegStr` + `WriteRegExpandStr`. Both now delegate to a small companion
script, `scripts/windows/set-user-path.ps1` (extracted to `$PLUGINSDIR`,
run via `nsExec`), which appends or removes `$INSTDIR` through .NET
registry APIs and broadcasts `WM_SETTINGCHANGE`. If PowerShell cannot
start, the step is skipped and nothing is written.

## Why

NSIS runtime strings cap at `NSIS_MAX_STRLEN`, 1024 characters in official
builds. Once a user's PATH is longer than that, `ReadRegStr` fails and
returns an empty string, so the installer's read-append-write block takes
its "PATH was empty" branch and **replaces the entire PATH with
`$INSTDIR`**, wiping every existing entry; the uninstaller's mirror path
writes an empty PATH. It only affects users whose PATH outgrew 1024
characters, and it bites on every install, upgrade, and reinstall — which
is why it never shows up on clean machines.

## Verification

Reproduced on Windows 11 with NSIS 3.10: a 1691-character `HKCU` PATH
becomes exactly `$INSTDIR` after a silent install. After the fix, the
helper appends correctly, stays idempotent, preserves `%VAR%` entries and
the `REG_EXPAND_SZ` kind, and removes cleanly on uninstall. The full
`hydra-installer.nsi` compiles cleanly with makensis 3.10 (PR CI does not
build the NSIS installer, so this was verified locally).
