### PR TITLE
Fix saving Alt-clicked links on Gecko

### DIFF
--- a/extensions/chrome/background.js
+++ b/extensions/chrome/background.js
@@ -1212,6 +1212,22 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         await sessionStore().set({ altTs: Date.now() });
         sendResponse({ ok: true });
         break;
+      case "alt-download": {
+        // Gecko's stand-in save (see the content script): the Alt bypass
+        // promises the browser keeps this one, and on Firefox only the
+        // extension can make that happen. `captureEligible` ignores our own
+        // downloads, so this cannot fall back into capture.
+        if (!/^https?:/i.test(msg.url || "")) {
+          return sendResponse({ ok: false, error: "not an http(s) link" });
+        }
+        try {
+          await chrome.downloads.download({ url: msg.url });
+          sendResponse({ ok: true });
+        } catch (e) {
+          sendResponse({ ok: false, error: String(e) });
+        }
+        break;
+      }
       case "get-state": {
         const state = await getState();
         const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });

--- a/extensions/chrome/content.js
+++ b/extensions/chrome/content.js
@@ -3,7 +3,8 @@
 //
 // Content script, three jobs:
 //  1. Stamp Alt+clicks so the background honors the "hold Alt to let the
-//     browser download normally" convention.
+//     browser download normally" convention, and on Gecko perform that
+//     download, because Firefox itself will not.
 //  2. Collect page links for "Download all links with Hydra".
 //  3. The selection pill: highlight one or more links and a floating
 //     "Download with Hydra" button appears next to the selection.
@@ -21,6 +22,38 @@ window.addEventListener(
   },
   true
 );
+
+// Gecko is the one browser where standing aside is not enough: it has shipped
+// `browser.altClickSave` defaulting to false since Firefox 13, so Alt+click
+// saves nothing there. Declining to capture and leaving the click to Firefox
+// therefore produced no download at all, in Hydra or in the browser. Chromium
+// and Safari do save the link themselves, and their own save is the better one
+// (Content-Disposition, the "always ask" setting, the Save As dialog), so the
+// extension only stands in where the browser declines.
+const ALT_SAVE_IS_OURS = /\bFirefox\/\d/.test(navigator.userAgent || "");
+
+// The link this click is asking the browser to save, or null if it is not
+// that gesture.
+function altSaveUrl(e) {
+  if (!ALT_SAVE_IS_OURS || !e.altKey || e.button !== 0 || e.defaultPrevented) return null;
+  const href = e.target?.closest?.("a[href]")?.href;
+  return href && /^https?:/i.test(href) ? href : null;
+}
+
+// Bubble phase, not capture: the page gets to claim its own Alt+click first,
+// and `defaultPrevented` above is only meaningful once it has.
+window.addEventListener("click", (e) => {
+  const url = altSaveUrl(e);
+  if (!url) return;
+  // Suppress Gecko's own handling too, so a profile that has turned
+  // `browser.altClickSave` back on downloads the file once, not twice.
+  e.preventDefault();
+  try {
+    chrome.runtime.sendMessage({ type: "alt-download", url });
+  } catch {
+    // Extension reloaded underneath us; harmless.
+  }
+});
 
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (msg?.type === "collect-links") {

--- a/extensions/safari/Resources/background.js
+++ b/extensions/safari/Resources/background.js
@@ -1212,6 +1212,22 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         await sessionStore().set({ altTs: Date.now() });
         sendResponse({ ok: true });
         break;
+      case "alt-download": {
+        // Gecko's stand-in save (see the content script): the Alt bypass
+        // promises the browser keeps this one, and on Firefox only the
+        // extension can make that happen. `captureEligible` ignores our own
+        // downloads, so this cannot fall back into capture.
+        if (!/^https?:/i.test(msg.url || "")) {
+          return sendResponse({ ok: false, error: "not an http(s) link" });
+        }
+        try {
+          await chrome.downloads.download({ url: msg.url });
+          sendResponse({ ok: true });
+        } catch (e) {
+          sendResponse({ ok: false, error: String(e) });
+        }
+        break;
+      }
       case "get-state": {
         const state = await getState();
         const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });

--- a/extensions/safari/Resources/content.js
+++ b/extensions/safari/Resources/content.js
@@ -3,7 +3,8 @@
 //
 // Content script, three jobs:
 //  1. Stamp Alt+clicks so the background honors the "hold Alt to let the
-//     browser download normally" convention.
+//     browser download normally" convention, and on Gecko perform that
+//     download, because Firefox itself will not.
 //  2. Collect page links for "Download all links with Hydra".
 //  3. The selection pill: highlight one or more links and a floating
 //     "Download with Hydra" button appears next to the selection.
@@ -21,6 +22,38 @@ window.addEventListener(
   },
   true
 );
+
+// Gecko is the one browser where standing aside is not enough: it has shipped
+// `browser.altClickSave` defaulting to false since Firefox 13, so Alt+click
+// saves nothing there. Declining to capture and leaving the click to Firefox
+// therefore produced no download at all, in Hydra or in the browser. Chromium
+// and Safari do save the link themselves, and their own save is the better one
+// (Content-Disposition, the "always ask" setting, the Save As dialog), so the
+// extension only stands in where the browser declines.
+const ALT_SAVE_IS_OURS = /\bFirefox\/\d/.test(navigator.userAgent || "");
+
+// The link this click is asking the browser to save, or null if it is not
+// that gesture.
+function altSaveUrl(e) {
+  if (!ALT_SAVE_IS_OURS || !e.altKey || e.button !== 0 || e.defaultPrevented) return null;
+  const href = e.target?.closest?.("a[href]")?.href;
+  return href && /^https?:/i.test(href) ? href : null;
+}
+
+// Bubble phase, not capture: the page gets to claim its own Alt+click first,
+// and `defaultPrevented` above is only meaningful once it has.
+window.addEventListener("click", (e) => {
+  const url = altSaveUrl(e);
+  if (!url) return;
+  // Suppress Gecko's own handling too, so a profile that has turned
+  // `browser.altClickSave` back on downloads the file once, not twice.
+  e.preventDefault();
+  try {
+    chrome.runtime.sendMessage({ type: "alt-download", url });
+  } catch {
+    // Extension reloaded underneath us; harmless.
+  }
+});
 
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (msg?.type === "collect-links") {

--- a/extensions/safari/Resources/manifest.json
+++ b/extensions/safari/Resources/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hydra Download Manager Integration",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "A browser integration for Hydra: right-click downloads, link selection, and media/HLS/DASH stream sniffing.",
   "browser_specific_settings": {
     "safari": {

--- a/extensions/tests/altclick.test.mjs
+++ b/extensions/tests/altclick.test.mjs
@@ -1,0 +1,73 @@
+// Copyright (C) 2026 Javad Rajabzadeh
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Which clicks the content script treats as "hold Alt and let the browser
+// have this one". Gecko is the only browser the extension saves for, so the
+// gesture test is where a wrong answer costs a download.
+// Run from the repository root:  node extensions/tests/altclick.test.mjs
+import { readFileSync } from "node:fs";
+
+const src = readFileSync("extensions/chrome/content.js", "utf8");
+
+// Lift the pure decision out of the content script, with `navigator` handed
+// in so each browser's user agent can be tried against the real source.
+function load(userAgent) {
+  const constAt = src.indexOf("const ALT_SAVE_IS_OURS");
+  const fnAt = src.indexOf("function altSaveUrl(");
+  if (constAt < 0 || fnAt < 0) throw new Error("missing the Alt-save decision");
+  const code =
+    src.slice(constAt, src.indexOf("\n", constAt) + 1) +
+    src.slice(fnAt, src.indexOf("\n}\n", fnAt) + 3);
+  return new Function("navigator", code + "return altSaveUrl;")({ userAgent });
+}
+
+const FIREFOX =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:155.0) Gecko/20100101 Firefox/155.0";
+const CHROME =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) " +
+  "Chrome/120.0.0.0 Safari/537.36";
+const SAFARI =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) " +
+  "Version/17.0 Safari/605.1.15";
+
+let fails = 0;
+const eq = (label, got, want) => {
+  if (got === want) console.log(`ok   ${label}`);
+  else {
+    fails++;
+    console.log(`FAIL ${label}\n  got  ${JSON.stringify(got)}\n  want ${JSON.stringify(want)}`);
+  }
+};
+
+// A click, shaped the way the listener reads one. `href` null stands for a
+// click that landed on no link at all.
+const click = ({ href = "https://cdn.example/pack.zip", ...rest } = {}) => ({
+  altKey: true,
+  button: 0,
+  defaultPrevented: false,
+  target: { closest: () => (href === null ? null : { href }) },
+  ...rest,
+});
+
+const onFirefox = load(FIREFOX);
+
+eq("firefox: an Alt+click on a link is ours to save", onFirefox(click()), "https://cdn.example/pack.zip");
+eq("chrome saves its own links", load(CHROME)(click()), null);
+eq("safari saves its own links", load(SAFARI)(click()), null);
+
+eq("a plain click is left alone", onFirefox(click({ altKey: false })), null);
+eq("a middle-click is a new tab, not a save", onFirefox(click({ button: 1 })), null);
+eq("a click on no link is left alone", onFirefox(click({ href: null })), null);
+
+// The page may own Alt+click for something of its own; by the bubble phase
+// its preventDefault() has already been recorded.
+eq("a page that claimed the click keeps it", onFirefox(click({ defaultPrevented: true })), null);
+
+// Only schemes the browser's download manager can fetch: the URL crosses into
+// downloads.download(), so a javascript: or file: href must not.
+eq("a javascript: link is not a download", onFirefox(click({ href: "javascript:alert(1)" })), null);
+eq("a file: link is not a download", onFirefox(click({ href: "file:///etc/passwd" })), null);
+eq("http is saved as readily as https", onFirefox(click({ href: "http://cdn.example/a.zip" })), "http://cdn.example/a.zip");
+
+console.log(fails ? `\n${fails} failed` : "\nall passed");
+process.exit(fails ? 1 : 0);

--- a/extensions/tests/capture.test.mjs
+++ b/extensions/tests/capture.test.mjs
@@ -55,6 +55,7 @@ function build({ hydraReply = { ok: true }, store = {}, gecko = false } = {}) {
       // off its absence, so a mock that always offers it can only ever test
       // the Chromium half.
       ...(gecko ? {} : { onDeterminingFilename: onDetermining }),
+      download: async (opts) => calls.push(["download", opts.url]),
       pause: async (id) => calls.push(["pause", id]),
       resume: async (id) => calls.push(["resume", id]),
       cancel: async (id) => calls.push(["cancel", id]),
@@ -163,6 +164,27 @@ function build({ hydraReply = { ok: true }, store = {}, gecko = false } = {}) {
   h.onDetermining.fire(item, () => {}); await tick(6);
   check("alt bypass: nothing is sent to Hydra", !h.sent.some((m) => m.type === "download"));
   check("alt bypass: the browser keeps the download", h.calls.some(([c]) => c === "resume"));
+}
+
+// ------------------------------- 3b. the Gecko stand-in for an Alt+click save
+//
+// `browser.altClickSave` has defaulted to false since Firefox 13, so standing
+// aside on Gecko left the user with no download anywhere. The extension saves
+// the link itself there; `captureEligible` skips its own downloads, so the
+// file cannot bounce straight back into Hydra.
+{
+  const h = build({ gecko: true });
+  await tick(4);
+  await h.send({ type: "alt-download", url: "https://cdn.example/pack.zip" });
+  check("alt stand-in: the browser is asked to download the link",
+    h.calls.some(([c, u]) => c === "download" && u === "https://cdn.example/pack.zip"),
+    JSON.stringify(h.calls));
+  check("alt stand-in: nothing is sent to Hydra", !h.sent.some((m) => m.type === "download"));
+
+  const refused = await h.send({ type: "alt-download", url: "javascript:alert(1)" });
+  check("alt stand-in: a non-http link is refused", refused?.ok === false);
+  check("alt stand-in: and never reaches the downloads API",
+    h.calls.filter(([c]) => c === "download").length === 1, JSON.stringify(h.calls));
 }
 
 // ------------------------------------------------------- 4. excluded site


### PR DESCRIPTION
Fixes #168 